### PR TITLE
uses minimum version for moment.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "angular": ">= 1.2",
     "angular-bindonce": "*",
-    "moment": "~2.6.0",
+    "moment": ">=2.6.0",
     "moment-range": "~1.0.1"
   },
   "license": "MIT",


### PR DESCRIPTION
Moment.js is currently capped at the old 2.6 revision and is a global; this breaks apps that rely on newer versions of Moment.
